### PR TITLE
fix github sponsors url

### DIFF
--- a/supplemental-ui/partials/header-content.hbs
+++ b/supplemental-ui/partials/header-content.hbs
@@ -29,7 +29,7 @@
           <div class="navbar-dropdown">
             <a class="navbar-item" href="/projectile/support.html">Support</a>
             <a class="navbar-item" href="/projectile/contributing.html">Contributing</a>
-            <a class="navbar-item" href="https://https://github.com/sponsors/bbatsov">GitHub Sponsors</a>
+            <a class="navbar-item" href="https://github.com/sponsors/bbatsov">GitHub Sponsors</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
I was browsing the documentation and noticed that the GitHub Sponsors link was broken.