### PR TITLE
Update the copyright notice in the site footer

### DIFF
--- a/supplemental-ui/partials/footer-content.hbs
+++ b/supplemental-ui/partials/footer-content.hbs
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <p>Copyright (C) 2011-2026 <a href="https://batsov.com">Bozhidar Batsov</a> and Projectile contributors.</p>
+  <p>Copyright &copy; 2011-2026 <a href="https://batsov.com">Bozhidar Batsov</a> and Projectile contributors.</p>
   <p>Except where otherwise noted, docs.projectile.mx is licensed under the <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution-ShareAlike 4.0 International</a> (CC BY-SA 4.0).</p>
 </footer>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@docsearch/js@alpha"></script>

--- a/supplemental-ui/partials/footer-content.hbs
+++ b/supplemental-ui/partials/footer-content.hbs
@@ -1,5 +1,5 @@
 <footer class="footer">
-  <p>Copyright (C) 2011-2025 <a href="https://batsov.com">Bozhidar Batsov</a> and Projectile contributors.</p>
+  <p>Copyright (C) 2011-2026 <a href="https://batsov.com">Bozhidar Batsov</a> and Projectile contributors.</p>
   <p>Except where otherwise noted, docs.projectile.mx is licensed under the <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution-ShareAlike 4.0 International</a> (CC BY-SA 4.0).</p>
 </footer>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@docsearch/js@alpha"></script>


### PR DESCRIPTION
Replace `2025` with `2026`.

In addition, replace `(C)` with the HTML entity `&copy;`.